### PR TITLE
Fix/make temperature optional

### DIFF
--- a/data/examples/ebus_toolbox.cfg
+++ b/data/examples/ebus_toolbox.cfg
@@ -20,13 +20,11 @@ cost_params = "./data/examples/cost_params.json"
 # Path to station data with stations heights and possibly more information
 station_data_path =  "data/examples/all_stations.csv"
 
-# Path to temperature csv. data with temperatures in deg Celsius over 0-23 hours
-# todo: this should be optional
-#outside_temperature_over_day_path =  "data/examples/default_temp_winter.csv"
+# Path to temperature csv. data with temperatures in deg Celsius over 0-23 hours (needed if mileage in vehicle types not constant)
+outside_temperature_over_day_path =  "data/examples/default_temp_winter.csv"
 
-# Path to level of loading csv. data with temperatures in deg Celsius over 0-23 hours
-# todo: this should be optional
-# level_of_loading_over_day_path =  "data/examples/default_level_of_loading_over_day.csv"
+# Path to level of loading csv. data with temperatures in deg Celsius over 0-23 hours (needed if mileage in vehicle types not constant)
+level_of_loading_over_day_path =  "data/examples/default_level_of_loading_over_day.csv"
 
 
 ##### SIMULATION HYPERPARAMETERS #####
@@ -63,16 +61,16 @@ desired_soc_opps = 0.8
 # Preferred charging type. Options: depb, oppb (default: oppb)
 preferred_charging_type = "depb"
 
-# min charging time at depots and opp stations [minutes] (default: 2)
-min_charging_time = 2
+# min charging time at depots and opp stations [minutes] (default: 0)
+min_charging_time = 0
 
 # buffer time at opp station if no specific buffer time is provided
-# via the electrified_stations.json [minutes] (default: 1)
+# via the electrified_stations.json [minutes] (default: 0)
 # Time specific buffer times can be set via a dict like:
 # {"10-22": 5, "else": 2} NOTE: else clause is a MUST!
 # The buffer time is deducted off of the planned standing time.
 # It may resemble things like delays and/or docking procedures
-# default_buffer_time_opps = 1
+default_buffer_time_opps = 0
 
 
 ##### PHYSICAL SETUP OF ENVIRONMENT #####

--- a/data/examples/vehicle_types.json
+++ b/data/examples/vehicle_types.json
@@ -6,8 +6,7 @@
             "charging_curve": [[0, 150], [0.8, 150], [1, 150]],
             "min_charging_power": 0,
             "v2g": false,
-            "v2g_power_factor": 0.5,
-            "mileage": 1
+            "v2g_power_factor": 0.5
         },
         "oppb": {
             "name": "articulated bus - opportunity charging",
@@ -15,8 +14,7 @@
             "charging_curve": [[0, 150], [0.8, 150], [1, 150]],
             "min_charging_power": 0,
             "v2g": false,
-            "v2g_power_factor": 0.5,
-            "mileage": 1
+            "v2g_power_factor": 0.5
         }
     },
     "CKB": {
@@ -26,7 +24,8 @@
             "charging_curve": [[0, 250], [0.8, 250], [1, 250]],
             "min_charging_power": 0,
             "v2g": false,
-            "mileage": 1
+            "mileage": "data/examples/energy_consumption_example.csv",
+            "hc": "winter"
         },
         "oppb": {
             "name": "articulated bus",
@@ -34,7 +33,8 @@
             "charging_curve": [[0, 190], [0.8, 190], [1, 190]],
             "min_charging_power": 0,
             "v2g": false,
-            "mileage": 1
+            "mileage": "data/examples/energy_consumption_example.csv",
+            "hc": "winter"
         }
     },
     "VDL": {
@@ -44,7 +44,8 @@
             "charging_curve": [[0, 250], [0.8, 250], [1, 250]],
             "min_charging_power": 0,
             "v2g": false,
-            "mileage": 1
+            "mileage": "data/examples/energy_consumption_example.csv",
+            "hc": "winter"
         },
         "oppb": {
             "name": "solo bus",
@@ -52,7 +53,8 @@
             "charging_curve": [[0, 250], [0.8, 250], [1, 250]],
             "min_charging_power": 0,
             "v2g": false,
-            "mileage": 1
+            "mileage": "data/examples/energy_consumption_example.csv",
+            "hc": "winter"
         }
     }
 }

--- a/ebus_toolbox/__main__.py
+++ b/ebus_toolbox/__main__.py
@@ -77,9 +77,9 @@ if __name__ == '__main__':
     parser.add_argument('--cost-params', help='include cost_params json',
                         default=None)
     parser.add_argument('--min-charging-time', help='define minimum time of charging',
-                        default=2)
+                        default=0)
     parser.add_argument('--default-buffer-time-opps', help='time to subtract off of standing time '
-                        'at opp station to simulate docking procedure.', default=1)
+                        'at opp station to simulate docking procedure.', default=0)
     parser.add_argument('--signal-time-dif', help='time difference between signal time and actual '
                                                   'start time of a vehicle event im min.',
                         default=10)

--- a/ebus_toolbox/simulate.py
+++ b/ebus_toolbox/simulate.py
@@ -52,7 +52,6 @@ def simulate(args):
             setattr(args, opt_key, opt_val)
 
     # setup consumption calculator that can be accessed by all trips
-    # todo: This should only be accessed if not all vehicles have constant consumption
     Trip.consumption = Consumption(vehicle_types,
                                    outside_temperatures=args.outside_temperature_over_day_path,
                                    level_of_loading_over_day=args.level_of_loading_over_day_path)


### PR DESCRIPTION
closes #78
parser now sets None default values for temperature and lol paths. Consumption calculation only uses calculation with these files if paths are provided. In case no paths are provided and (the vehicle mileage is not constant and (temp or lol are missing in the trips file)) no consumption can be calculated. An error is raised and a error description is given.