### PR TITLE
Add spiceEV abortion handling to toolbox

### DIFF
--- a/ebus_toolbox/schedule.py
+++ b/ebus_toolbox/schedule.py
@@ -183,7 +183,8 @@ class Schedule:
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
             scenario.run('distributed', vars(args).copy())
-
+        assert scenario.step_i == scenario.n_intervals - 1, \
+            'spiceEV simulation aborted, see above for details'
         return scenario
 
     def set_charging_type(self, ct, rotation_ids=None):


### PR DESCRIPTION
When spiceEV simulaiton crashes, the eBus-Toolbox should be terminated and prompt an error