### PR TITLE
cost/report: use 'CS in use' instead of # occ. CS

### DIFF
--- a/ebus_toolbox/costs.py
+++ b/ebus_toolbox/costs.py
@@ -81,7 +81,7 @@ def calculate_costs(c_params, scenario, schedule, args):
             # get max. nr of occupied CS per grid connector
             gc = getattr(scenario, f"{gcID}_timeseries")
             costs["c_cs"] += (c_params["cs"]["capex_opps_per_kW"] * vars(args)["cs_power_opps"] *
-                              max(gc["# occupied CS"]))
+                              max(gc["CS in use"]))
     # calculate annual cost of charging stations, depending on their lifetime
     costs["c_cs_annual"] = costs["c_cs"] / c_params["cs"]["lifetime_cs"]
 

--- a/ebus_toolbox/report.py
+++ b/ebus_toolbox/report.py
@@ -64,15 +64,15 @@ def generate_gc_overview(schedule, scenario, args):
             if gc in used_gc_list:
                 ts = getattr(scenario, f"{gc}_timeseries")
                 max_gc_power = -min(ts["grid power [kW]"])
-                max_nr_cs = max(ts["# occupied CS"])
+                max_nr_cs = max(ts["CS in use"])
                 sum_of_cs_energy = sum(ts["sum CS power"]) * args.interval/60
 
                 # use factors: to which percentage of time are the three least used CS in use
-                num_ts = len(ts["# occupied CS"])  # number of timesteps
+                num_ts = scenario.n_intervals  # number of timesteps
                 # three least used CS. Less if number of CS is lower.
                 least_used_num = min(3, max_nr_cs)
                 # count number of timesteps with this exact number of occupied CS
-                count_nr_cs = [ts["# occupied CS"].count(max_nr_cs - i) for i in range(
+                count_nr_cs = [ts["CS in use"].count(max_nr_cs - i) for i in range(
                     least_used_num)]
                 use_factors = [sum(count_nr_cs[:i + 1]) / num_ts for i in range(
                     least_used_num)]  # relative occupancy with at least this number of occupied CS


### PR DESCRIPTION
In SpiceEV report.aggregate_timeseries, a new column 'CS in use' has been added. This counts the number of CS actually delivering power. This is a better input for the cost calculation and use factors.