### PR TITLE
rotation.add_trip: fixed consumption calc if ct is given

### DIFF
--- a/simba/rotation.py
+++ b/simba/rotation.py
@@ -28,6 +28,7 @@ class Rotation:
 
         :param trip: Information on trip to be added to rotation
         :type trip: dict
+        :raises Exception: if charging type of trip and rotation differ
         """
         new_trip = Trip(self, **trip)
 
@@ -57,16 +58,21 @@ class Rotation:
 
         # set charging type if given
         charging_type = trip.get('charging_type')
+        self.trips.append(new_trip)
         if charging_type in ['depb', 'oppb']:
-            assert self.charging_type is None or self.charging_type == charging_type, (
-                f"Two trips of rotation {self.id} have distinct charging types")
             assert self.schedule.vehicle_types.get(
                 self.vehicle_type, {}).get(charging_type) is not None, (
                 f"The required vehicle type {self.vehicle_type}({charging_type}) "
                 "is not given in the vehicle_types.json file.")
-            self.set_charging_type(charging_type)
-
-        self.trips.append(new_trip)
+            if self.charging_type is None:
+                # set CT for whole rotation
+                self.set_charging_type(charging_type)
+            elif self.charging_type == charging_type:
+                # same CT as other trips: just add trip consumption
+                self.consumption += new_trip.calculate_consumption()
+            else:
+                # different CT than rotation: error
+                raise Exception(f"Two trips of rotation {self.id} have distinct charging types")
 
     def calculate_consumption(self):
         """ Calculate consumption of this rotation and all its trips.

--- a/simba/schedule.py
+++ b/simba/schedule.py
@@ -608,6 +608,8 @@ class Schedule:
                         "estimated_time_of_arrival": arrival_time.isoformat()
                     }
                 })
+                assert trip.delta_soc is not None, (
+                    "Trip delta_soc is None. Did you forget to calculate consumption?")
 
                 # create arrival event
                 events["vehicle_events"].append({

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -178,7 +178,7 @@ class TestSchedule:
         sched, scen = self.basic_run()
 
         neg_rots = sched.get_negative_rotations(scen)
-        assert '1' in neg_rots
+        assert '2' in neg_rots
 
     def test_rotation_filter(self, tmp_path):
         s = schedule.Schedule(self.vehicle_types, self.electrified_stations, **mandatory_args)


### PR DESCRIPTION
Changed logic of rotation.add_trip. Consumption for trips was not calculated when trip charging_type was given (eg through trips.csv) and rotation already had a charging type. 
Added check in schedule.generate_scenario that each trip has a delta_soc. 
Changed expected result in test_schedule.test_get_negative_rotations.