### PR TITLE
can ignore output directory

### DIFF
--- a/data/examples/simba.cfg
+++ b/data/examples/simba.cfg
@@ -4,6 +4,7 @@
 input_schedule = data/examples/trips_example.csv
 # Output files are stored here (defaults to: data/sim_outputs)
 # Attention: In Windows the path-length is limited to 256 characters!
+# Deactivate storage of output by setting output_directory = null
 output_directory = data/output/
 # Electrified stations (required)
 electrified_stations = data/examples/electrified_stations.json

--- a/docs/source/simulation_parameters.rst
+++ b/docs/source/simulation_parameters.rst
@@ -35,7 +35,7 @@ The example (data/simba.cfg) contains parameter descriptions which are explained
    * - Output_directory
      - Data/sim_outputs
      - Path as string
-     - Output files are stored here
+     - Output files are stored here; set to null to deactivate
    * - electrified_stations
      - ./data/examples/vehicle_types.json
      - Path as string

--- a/simba/__main__.py
+++ b/simba/__main__.py
@@ -9,26 +9,32 @@ if __name__ == '__main__':
     args = util.get_args()
 
     time_str = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-    args.output_directory = Path(args.output_directory) / time_str
-    # create subfolder for specific sim results with timestamp.
-    # if folder doesn't exist, create folder.
-    # needs to happen after set_options_from_config since
-    # args.output_directory can be overwritten by config
-    args.output_directory_input = args.output_directory / "input_data"
-    args.output_directory_input.mkdir(parents=True, exist_ok=True)
+    if args.output_directory is not None:
+        args.output_directory = Path(args.output_directory) / time_str
+        # create subfolder for specific sim results with timestamp.
+        # if folder doesn't exist, create folder.
+        # needs to happen after set_options_from_config since
+        # args.output_directory can be overwritten by config
+        args.output_directory_input = args.output_directory / "input_data"
+        try:
+            args.output_directory_input.mkdir(parents=True, exist_ok=True)
+        except NotADirectoryError:
+            # can't create new directory (may be write protected): no output
+            args.output_directory = None
+    if args.output_directory is not None:
+        # copy input files to output to ensure reproducibility
+        copy_list = [args.config, args.electrified_stations, args.vehicle_types]
+        if "station_optimization" in args.mode:
+            copy_list.append(args.optimizer_config)
 
-    # copy input files to output to ensure reproducibility
-    copy_list = [args.config, args.electrified_stations, args.vehicle_types]
-    if "station_optimization" in args.mode:
-        copy_list.append(args.optimizer_config)
+        # only copy cost params if they exist
+        if args.cost_parameters_file is not None:
+            copy_list.append(args.cost_parameters_file)
+        for c_file in map(Path, copy_list):
+            shutil.copy(c_file, args.output_directory_input / c_file.name)
 
-    # only copy cost params if they exist
-    if args.cost_parameters_file is not None:
-        copy_list.append(args.cost_parameters_file)
-    for c_file in map(Path, copy_list):
-        shutil.copy(c_file, args.output_directory_input / c_file.name)
+        util.save_version(args.output_directory_input / "program_version.txt")
 
-    util.save_version(args.output_directory_input / "program_version.txt")
     util.setup_logging(args, time_str)
 
     try:

--- a/simba/simulate.py
+++ b/simba/simulate.py
@@ -136,9 +136,10 @@ def modes_simulation(schedule, scenario, args):
             if scenario is not None and scenario.step_i > 0:
                 # generate plot of failed scenario
                 args.mode = args.mode[:i] + ["ABORTED"]
-                create_results_directory(args, i+1)
-                report.generate_plots(scenario, args)
-                logging.info(f"Created plot of failed scenario in {args.results_directory}")
+                if args.output_directory is None:
+                    create_results_directory(args, i+1)
+                    report.generate_plots(scenario, args)
+                    logging.info(f"Created plot of failed scenario in {args.results_directory}")
             # continue with other modes after error
 
     # all modes done
@@ -222,6 +223,9 @@ class Mode:
         return schedule, scenario
 
     def report(schedule, scenario, args, i):
+        if args.output_directory is None:
+            return schedule, scenario
+
         # create report based on all previous modes
         if args.cost_calculation:
             # cost calculation part of report
@@ -240,6 +244,9 @@ def create_results_directory(args, i):
     :param i: iteration number of loop
     :type i: int
     """
+
+    if args.output_directory is None:
+        return
 
     prior_reports = sum([m.count('report') for m in args.mode[:i]])
     report_name = f"report_{prior_reports+1}"

--- a/simba/util.py
+++ b/simba/util.py
@@ -224,7 +224,7 @@ def setup_logging(args, time_str):
     # set up logging
     # always to console
     log_handlers = [logging.StreamHandler()]
-    if args.logfile is not None:
+    if args.logfile is not None and args.output_directory is not None:
         # optionally to file in output dir
         if args.logfile:
             log_name = args.logfile
@@ -246,9 +246,9 @@ def get_args():
         description='SimBA - Simulation toolbox for Bus Applications.')
 
     # #### Paths #####
-    parser.add_argument('--input-schedule', nargs='?',
+    parser.add_argument('--input-schedule',
                         help='Path to CSV file containing all trips of schedule to be analyzed.')
-    parser.add_argument('--output-directory', default="data/sim_outputs", nargs='?',
+    parser.add_argument('--output-directory', default="data/sim_outputs",
                         help='Location where all simulation outputs are stored')
     parser.add_argument('--electrified-stations', help='include electrified_stations json')
     parser.add_argument('--vehicle-types', default="data/examples/vehicle_types.json",


### PR DESCRIPTION
When output_directory is null, don't create output directory. This is also helpful if no directory can be created (e.g. when writing to /dev/null). No files are saved in this case (input, log file or reports).