### PR TITLE
forward substrategy instead of distributed to spiceEV price calculation

### DIFF
--- a/simba/costs.py
+++ b/simba/costs.py
@@ -220,7 +220,7 @@ def calculate_costs(c_params, scenario, schedule, args):
 
         # calculate costs for electricity
         costs_electricity = calc_costs_spice_ev(
-            strategy=args.strategy,
+            strategy=vars(args)["strategy_"+station.get("type")],
             voltage_level=gc.voltage_level,
             interval=scenario.interval,
             timestamps_list=timeseries.get("time"),

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -120,6 +120,7 @@ class TestSimulate:
         values["cost_calculation"] = True
         values["output_directory"] = tmp_path
         values["strategy"] = "distributed"
+        values["strategy_deps"] = "balanced"
         values["show_plots"] = False
         # tuned so that some rotations don't complete
         values["days"] = .33


### PR DESCRIPTION
Das Problem ist, dass die Kostenberechnung in SpiceES nicht zwischen den verschiedenen Substrategien in distributed unterscheidet. Die Kosten werden also nach der distributed Strategie berechnet und da wird die price_list gar nicht verwendet, sondern der Arbeitspreis (commodity charge) direkt aus dem Preisblatt des Netzbetreibers (price sheet) zusammen mit der Netzzeitreihe berechnet. Um calculate costs sinnvoll mit distributed und allen unterstrategien nutzen zu können, muss in SimBA die substrategy an die cost calculation in SpiceEV übergeben werden.
