### PR TITLE
Make min_standing_time and earliest depature properties

### DIFF
--- a/data/examples/time_windows.json
+++ b/data/examples/time_windows.json
@@ -15,7 +15,7 @@
       "start": "2022-03-01",
       "end": "2022-05-31",
       "windows": {
-        "MV": [["03:00", "04:30"]]  // only relevant time window in example scenario
+        "MV": [["03:00", "04:55"]]  // only relevant time window in example scenario
       }
     },
     "summer": {

--- a/simba/rotation.py
+++ b/simba/rotation.py
@@ -108,9 +108,17 @@ class Rotation:
         # consumption may have changed with new charging type
         self.consumption = self.calculate_consumption()
 
-        # calculate earliest possible departure for this bus after completion
-        # of this rotation
-        if ct == "depb":
+        # recalculate consumption
+        self.schedule.consumption += self.consumption - old_consumption
+
+    @property
+    def earliest_departure_next_rot(self):
+        return self.arrival_time + datetime.timedelta(hours=self.min_standing_time)
+
+    @property
+    def min_standing_time(self):
+        assert self.charging_type in ["depb", "oppb"]
+        if self.charging_type == "depb":
             capacity_depb = self.schedule.vehicle_types[self.vehicle_type]["depb"]["capacity"]
             # minimum time needed to recharge consumed power from depot charger
             min_standing_time = (self.consumption / self.schedule.cs_power_deps_depb)
@@ -119,13 +127,8 @@ class Rotation:
                                          * self.schedule.min_recharge_deps_depb)
             if min_standing_time > desired_max_standing_time:
                 min_standing_time = desired_max_standing_time
-        elif ct == "oppb":
+        elif self.charging_type == "oppb":
             capacity_oppb = self.schedule.vehicle_types[self.vehicle_type]["oppb"]["capacity"]
             min_standing_time = ((capacity_oppb / self.schedule.cs_power_deps_oppb)
                                  * self.schedule.min_recharge_deps_oppb)
-
-        self.earliest_departure_next_rot = \
-            self.arrival_time + datetime.timedelta(hours=min_standing_time)
-
-        # recalculate consumption
-        self.schedule.consumption += self.consumption - old_consumption
+        return min_standing_time

--- a/simba/rotation.py
+++ b/simba/rotation.py
@@ -108,7 +108,7 @@ class Rotation:
         # consumption may have changed with new charging type
         self.consumption = self.calculate_consumption()
 
-        # recalculate consumption
+        # recalculate schedule consumption: update for new rotation consumption
         self.schedule.consumption += self.consumption - old_consumption
 
     @property


### PR DESCRIPTION
fixes #142 

Defining charging types in trips.csv leads to wrong vehicle assigning since earliest_departures are wrongly calculated at times when the rotation is not complete yet. Making them properties guarantees that assign_vehicles gets the correct values