### PR TITLE
refactor of Trip and Rotation

### DIFF
--- a/simba/optimizer_util.py
+++ b/simba/optimizer_util.py
@@ -20,7 +20,6 @@ if typing.TYPE_CHECKING:
 
 from simba.consumption import Consumption
 from simba.trip import Trip
-from simba.util import get_buffer_time as get_buffer_time_util
 from spice_ev.report import generate_soc_timeseries
 
 
@@ -222,7 +221,7 @@ def get_charging_time(trip1, trip2, args):
     :rtype: float
     """
     standing_time_min = (trip2.departure_time - trip1.arrival_time) / timedelta(minutes=1)
-    buffer_time = (get_buffer_time(trip1, args.default_buffer_time_opps) / timedelta(minutes=1))
+    buffer_time = trip1.get_buffer_time(default=args.default_buffer_time_opps)
     standing_time_min -= buffer_time
 
     if args.min_charging_time > standing_time_min:
@@ -230,31 +229,19 @@ def get_charging_time(trip1, trip2, args):
     return max(0, standing_time_min)
 
 
-def get_charging_start(trip1, args):
+def get_charging_start(trip, args):
     """ Return the possible start time of charging.
 
     This function considers the buffer times before charging can take place
 
-    :param trip1: trip to be checked
-    :type trip1: simba.trip.Trip
+    :param trip: trip to be checked
+    :type trip: simba.trip.Trip
     :param args: arguments including default buffer time
     :type args: Namespace
     :return: First possible charging time as datetime object
     """
-    buffer_time = get_buffer_time(trip1, args.default_buffer_time_opps)
-    return trip1.arrival_time+buffer_time
-
-
-def get_buffer_time(trip, default_buffer_time_opps):
-    """ Return the buffer time as timedelta object.
-
-    :param trip: trip to be checked
-    :type trip: simba.trip.Trip
-    :param default_buffer_time_opps: the default buffer time at opps charging stations
-    :return: buffer time
-    :rtype: datetime.timedelta
-    """
-    return timedelta(minutes=get_buffer_time_util(trip, default_buffer_time_opps))
+    buffer_time = trip.get_buffer_time(default=args.default_buffer_time_opps)
+    return trip.arrival_time + buffer_time
 
 
 def get_index_by_time(scenario, search_time):

--- a/simba/station_optimizer.py
+++ b/simba/station_optimizer.py
@@ -3,7 +3,7 @@
 import logging
 import pickle
 from copy import deepcopy, copy
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import Path
 import numpy as np
 
@@ -495,9 +495,7 @@ class StationOptimizer:
 
                 d_soc = opt_util.get_delta_soc(
                     soc_over_time_curve, soc[idx], standing_time_min, self)
-                buffer_idx = int(
-                    (opt_util.get_buffer_time(trip, self.args.default_buffer_time_opps))
-                    / timedelta(minutes=1))
+                buffer_idx = int(trip.get_buffer_time(default=self.args.default_buffer_time_opps))
                 delta_idx = int(standing_time_min) + 1
                 old_soc = soc[idx + buffer_idx:idx + buffer_idx + delta_idx].copy()
                 soc[idx + buffer_idx:] += d_soc

--- a/simba/trip.py
+++ b/simba/trip.py
@@ -1,54 +1,77 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
 
 class Trip:
-    def __init__(self, rotation, departure_time, departure_name,
-                 arrival_time, arrival_name, distance, **kwargs):
+    def __init__(self, departure_time, departure_name,
+                 arrival_time, arrival_name, distance,
+                 line=None, temperature=None, level_of_loading=None, mean_speed=None,
+                 height_diff=None, station_data=None,
+                 charging_type=None, vehicle_type=None,
+                 ):
+        self.departure_time = departure_time
         self.departure_name = departure_name
-        self.departure_time = datetime.fromisoformat(departure_time)
-        self.arrival_time = datetime.fromisoformat(arrival_time)
+        self.arrival_time = arrival_time
         self.arrival_name = arrival_name
         self.distance = float(distance)
-        self.line = kwargs.get('line', None)
-        self.temperature = kwargs.get('temperature', None)
+
+        # optional / computed
+        self.height_diff = height_diff  # m
+        self.level_of_loading = level_of_loading  # [0-1]
+        self.line = line
+        self.mean_speed = mean_speed  # km/h
+        self.temperature = temperature  # deg C
+
+        # needed to update rotation properties when adding trip
+        self.charging_type = charging_type  # oppb/depb/None
+        self.vehicle_type = vehicle_type
+
+        # set when added to rotation
+        # needed for consumption calculation and other references, like schedule
+        # !Circular reference! problematic for garbage collector in older Python versions
+        self.rotation = None
+
+        # set after calculating consumption
+        self.consumption = None  # kWh
+        self.delta_soc = None
+
+        # ---- cast / compute options ---- #
+        # cast times to datetime
+        if type(departure_time) is str:
+            self.departure_time = datetime.fromisoformat(departure_time)
+        if type(arrival_time) is str:
+            self.arrival_time = datetime.fromisoformat(arrival_time)
+
+        # cast temperature to float
         try:
             self.temperature = float(self.temperature)
             # In case of empty temperature column or no column at all
         except (TypeError, ValueError):
             self.temperature = None
 
-        height_diff = kwargs.get("height_difference", None)
+        # get height difference from station data if not given
+        assert height_diff is not None or station_data is not None, (
+            "New trip: need either height_diff or station_data")
         if height_diff is None:
-            station_data = kwargs.get("station_data", dict())
             try:
-                height_diff = station_data[self.arrival_name]["elevation"] \
-                              - station_data[self.departure_name]["elevation"]
+                self.height_diff = (station_data[self.arrival_name]["elevation"]
+                                    - station_data[self.departure_name]["elevation"])
             except (KeyError, TypeError):
-                height_diff = 0
-        self.height_diff = height_diff
-        self.level_of_loading = kwargs.get('level_of_loading', None)
+                self.height_diff = 0
+
+        # clip level of loading to [0,1],
+        # but may also be None in case of empty temperature column or no column at all
         try:
-            # Clip level of loading to [0,1]
-            self.level_of_loading = max(0, min(float(self.level_of_loading), 1))
-        # In case of empty temperature column or no column at all
+            self.level_of_loading = max(0, min(float(level_of_loading), 1))
         except (TypeError, ValueError):
             self.level_of_loading = None
-        # mean speed in km/h from distance and travel time or from initialization
-        # travel time is at least 1 min
-        mean_speed = kwargs.get("mean_speed", (self.distance / 1000) /
-                                max(1 / 60, ((self.arrival_time - self.departure_time) / timedelta(
-                                    hours=1))))
-        self.mean_speed = mean_speed
 
-        # Attention: Circular reference!
-        # While a rotation carries a references to this trip, this trip
-        # itself carries the below reference to that rotation as well.
-        # For Python versions < 3.4 this created a problem for the garbage
-        # collector.
-        self.rotation = rotation
-
-        self.consumption = None  # kWh
-        self.delta_soc = None
+        # mean speed in km/h from distance and travel time if not given
+        if mean_speed is None:
+            travel_time = (self.arrival_time - self.departure_time).total_seconds()
+            # travel time is at least 1 min
+            travel_time = max(travel_time, 60)
+            mean_speed = self.distance * travel_time  # m/s
+            self.mean_speed = mean_speed * 3.6  # km/h
 
     def calculate_consumption(self):
         """ Compute consumption for this trip.
@@ -59,18 +82,57 @@ class Trip:
         """
 
         try:
-            self.consumption, self.delta_soc = \
-                Trip.consumption.calculate_consumption(self.arrival_time,
-                                                       self.distance,
-                                                       self.rotation.vehicle_type,
-                                                       self.rotation.charging_type,
-                                                       temp=self.temperature,
-                                                       height_diff=self.height_diff,
-                                                       level_of_loading=self.level_of_loading,
-                                                       mean_speed=self.mean_speed)
+            self.consumption, self.delta_soc = Trip.consumption.calculate_consumption(
+                self.arrival_time, self.distance,
+                self.vehicle_type, self.charging_type,
+                temp=self.temperature,  height_diff=self.height_diff,
+                level_of_loading=self.level_of_loading, mean_speed=self.mean_speed)
         except AttributeError as e:
             raise Exception(
-                'To calculate consumption, a consumption object needs to be constructed \
-                and linked to Trip class.').with_traceback(e.__traceback__)
+                'To calculate consumption, a consumption object needs to be constructed '
+                'and linked to Trip class.').with_traceback(e.__traceback__)
 
         return self.consumption
+
+    def get_buffer_time(self, default=0):
+        """ Get buffer time at arrival station of a trip.
+
+        Buffer time is an abstraction of delays like
+        docking procedures and is added to the planned arrival time.
+
+        :param default: Default buffer time if no station specific buffer time is given. [minutes]
+        :type default: dict, numeric
+        :return: buffer time in minutes
+        :rtype: dict or int
+
+        NOTE: Buffer time dictionaries map hours of the day to a buffer time.
+        Keys are ranges of hours and corresponding values provide buffer time in
+        minutes for that time range.
+        An entry with key "else" is a must if not all hours of the day are covered.
+        Example: ``buffer_time = {"10-22": 2, "22-6": 3, "else": 1}``
+        """
+
+        schedule = self.rotation.schedule
+        buffer_time = schedule.stations.get(self.arrival_name, {}).get('buffer_time', default)
+
+        # distinct buffer times depending on time of day can be provided
+        # in that case buffer time is of type dict instead of int
+        if isinstance(buffer_time, dict):
+            # sort dict to make sure 'else' key is last key
+            buffer_time = {key: buffer_time[key] for key in sorted(buffer_time)}
+            current_hour = self.arrival_time.hour
+            for time_range, buffer in buffer_time.items():
+                if time_range == 'else':
+                    buffer_time = buffer
+                    break
+                else:
+                    start_hour, end_hour = [int(t) for t in time_range.split('-')]
+                    if end_hour < start_hour:
+                        if current_hour >= start_hour or current_hour < end_hour:
+                            buffer_time = buffer
+                            break
+                    else:
+                        if start_hour <= current_hour < end_hour:
+                            buffer_time = buffer
+                            break
+        return buffer_time

--- a/simba/util.py
+++ b/simba/util.py
@@ -16,52 +16,6 @@ def save_version(file_path):
         f.write("Git Hash SimBA:" + get_git_revision_hash())
 
 
-def get_buffer_time(trip, default=0):
-    """ Get buffer time at arrival station of a trip.
-
-    Buffer time is an abstraction of delays like
-    docking procedures and is added to the planned arrival time.
-
-    :param trip: trip to calculate buffer time for
-    :type trip: simba.Trip
-    :param default: Default buffer time if no station specific buffer time is given. [minutes]
-    :type default: dict, numeric
-    :return: buffer time in minutes
-    :rtype: dict or int
-
-    NOTE: Buffer time dictionaries map hours of the day to a buffer time.
-    Keys are ranges of hours and corresponding values provide buffer time in
-    minutes for that time range.
-    An entry with key "else" is a must if not all hours of the day are covered.
-    Example: ``buffer_time = {"10-22": 2, "22-6": 3, "else": 1}``
-    """
-
-    schedule = trip.rotation.schedule
-    buffer_time = schedule.stations.get(trip.arrival_name, {}).get('buffer_time', default)
-
-    # distinct buffer times depending on time of day can be provided
-    # in that case buffer time is of type dict instead of int
-    if isinstance(buffer_time, dict):
-        # sort dict to make sure 'else' key is last key
-        buffer_time = {key: buffer_time[key] for key in sorted(buffer_time)}
-        current_hour = trip.arrival_time.hour
-        for time_range, buffer in buffer_time.items():
-            if time_range == 'else':
-                buffer_time = buffer
-                break
-            else:
-                start_hour, end_hour = [int(t) for t in time_range.split('-')]
-                if end_hour < start_hour:
-                    if current_hour >= start_hour or current_hour < end_hour:
-                        buffer_time = buffer
-                        break
-                else:
-                    if start_hour <= current_hour < end_hour:
-                        buffer_time = buffer
-                        break
-    return buffer_time
-
-
 def uncomment_json_file(f, char='//'):
     """ Remove comments from JSON file.
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -26,4 +26,7 @@ def generate_basic_schedule():
         "cs_power_deps_oppb": 150
     }
 
-    return schedule.Schedule.from_csv(schedule_path, vehicle_types, stations, **mandatory_args)
+    s = schedule.Schedule.from_csv(schedule_path, vehicle_types, stations, **mandatory_args)
+    s.calculate_consumption()
+
+    return s

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -264,6 +264,7 @@ class TestSchedule(BasicSchedule):
         generated_schedule = schedule.Schedule.from_csv(
             path_to_trips, self.vehicle_types, electrified_stations, **mandatory_args,
             station_data_path=path_to_all_station_data)
+        generated_schedule.calculate_consumption()
 
         set_options_from_config(args, verbose=False)
         args.ALLOW_NEGATIVE_SOC = True
@@ -286,6 +287,7 @@ class TestSchedule(BasicSchedule):
         generated_schedule = schedule.Schedule.from_csv(
             path_to_trips, self.vehicle_types, electrified_stations, **mandatory_args,
             station_data_path=path_to_all_station_data)
+        generated_schedule.calculate_consumption()
 
         set_options_from_config(args, verbose=False)
 

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -187,7 +187,7 @@ class TestSchedule(BasicSchedule):
         })
         # add dummy rotations
         s.rotations = {
-            str(i): rotation.Rotation(id=str(i), vehicle_type="", schedule=None)
+            str(i): rotation.Rotation(id=str(i), schedule=None)
             for i in range(6)
         }
         s.original_rotations = deepcopy(s.rotations)


### PR DESCRIPTION
Changes to Rotation:
- remove vehicle_type as init argument, use Trip.vehicle_type to set attribute
- Rotation.add_trip now expects a Trip object
- change Rotation.add_trip to Rotation.add_trip_from_dict, which builds a Trip and calls Rotation.add_trip
- rework of vehicle_type and charging_type assignment from given trips in add_trip
- better structure and logic flow
- keep charging_type of rotation and its trips consistent

Changes to Trip:
- explicit arguments with defaults instead of kwargs
- better attribute structure to see all at a glance
- use Trip.vehicle/charging_type for consumption calculation instead of rotation (allows for indipendent trips)
- make util.get_buffer_time(trip) a function of Trip

General changes:
- remove optimizer_util.get_buffer_time (not needed)
- add reasoning to expected values of test_util.test_get_buffer_time