### PR TITLE
Feature/idle consumption

### DIFF
--- a/data/examples/vehicle_types.json
+++ b/data/examples/vehicle_types.json
@@ -8,7 +8,7 @@
             "v2g": false,  // Is vehicle capable of vehicle to grid?
             "mileage": "data/examples/energy_consumption_example.csv",  // mileage in kWh/km or link to consumption.csv
             "battery_efficiency": 0.95,  // optional. default: 0.95
-            "idle_consumption" : 0.8 // [kWh/h] consumption while standing
+            "idle_consumption" : 0.0 // [kWh/h] consumption while standing during a rotation
         },
         "oppb": {
             "name": "articulated bus - opportunity charging",
@@ -17,7 +17,7 @@
             "min_charging_power": 0,
             "v2g": false,
             "mileage": "data/examples/energy_consumption_example.csv",
-            "idle_consumption" : 0.8, // [kWh/h] consumption while standing
+            "idle_consumption" : 0.0 // [kWh/h] consumption while standing during a rotation
         }
     },
     "SB": {
@@ -28,7 +28,7 @@
             "min_charging_power": 0,
             "v2g": false,
             "mileage": 1.2,
-            "idle_consumption" : 0.8, // [kWh/h] consumption while standing
+            "idle_consumption" : 0.0 // [kWh/h] consumption while standing during a rotation
         },
         "oppb": {
             "name": "solo bus - opportunity charging",
@@ -37,7 +37,7 @@
             "min_charging_power": 0,
             "v2g": false,
             "mileage": 1.1,
-            "idle_consumption" : 0.8, // [kWh/h] consumption while standing
+            "idle_consumption" : 0.0 // [kWh/h] consumption while standing during a rotation
         }
     }
 }

--- a/data/examples/vehicle_types.json
+++ b/data/examples/vehicle_types.json
@@ -17,7 +17,7 @@
             "min_charging_power": 0,
             "v2g": false,
             "mileage": "data/examples/energy_consumption_example.csv",
-            "idle_consumption" : 0.0 // [kWh/h] consumption while standing during a rotation
+            "idle_consumption" : 0.0
         }
     },
     "SB": {
@@ -28,7 +28,7 @@
             "min_charging_power": 0,
             "v2g": false,
             "mileage": 1.2,
-            "idle_consumption" : 0.0 // [kWh/h] consumption while standing during a rotation
+            "idle_consumption" : 0.0
         },
         "oppb": {
             "name": "solo bus - opportunity charging",
@@ -37,7 +37,7 @@
             "min_charging_power": 0,
             "v2g": false,
             "mileage": 1.1,
-            "idle_consumption" : 0.0 // [kWh/h] consumption while standing during a rotation
+            "idle_consumption" : 0.0
         }
     }
 }

--- a/data/examples/vehicle_types.json
+++ b/data/examples/vehicle_types.json
@@ -7,7 +7,8 @@
             "min_charging_power": 0,  // min charging power in KW
             "v2g": false,  // Is vehicle capable of vehicle to grid?
             "mileage": "data/examples/energy_consumption_example.csv",  // mileage in kWh/km or link to consumption.csv
-            "battery_efficiency": 0.95  // optional. default: 0.95
+            "battery_efficiency": 0.95,  // optional. default: 0.95
+            "idle_consumption" : 0.8 // [kWh/h] consumption while standing
         },
         "oppb": {
             "name": "articulated bus - opportunity charging",
@@ -15,7 +16,8 @@
             "charging_curve": [[0, 250], [0.8, 250], [1, 25]],
             "min_charging_power": 0,
             "v2g": false,
-            "mileage": "data/examples/energy_consumption_example.csv"
+            "mileage": "data/examples/energy_consumption_example.csv",
+            "idle_consumption" : 0.8, // [kWh/h] consumption while standing
         }
     },
     "SB": {
@@ -25,7 +27,8 @@
             "charging_curve": [[0, 150], [0.8, 150], [1, 15]],
             "min_charging_power": 0,
             "v2g": false,
-            "mileage": 1.2
+            "mileage": 1.2,
+            "idle_consumption" : 0.8, // [kWh/h] consumption while standing
         },
         "oppb": {
             "name": "solo bus - opportunity charging",
@@ -33,7 +36,8 @@
             "charging_curve": [[0, 250], [0.8, 250], [1, 25]],
             "min_charging_power": 0,
             "v2g": false,
-            "mileage": 1.1
+            "mileage": 1.1,
+            "idle_consumption" : 0.8, // [kWh/h] consumption while standing
         }
     }
 }

--- a/simba/optimization.py
+++ b/simba/optimization.py
@@ -345,7 +345,7 @@ def recombination(schedule, args, trips, depot_trips):
             # rotation.add_trip needs dict, but consumption calculation is better done on Trip obj:
             # create temporary depot trip object for consumption calculation
             tmp_trip = Trip(rotation, **depot_trip)
-            tmp_trip.calculate_consumption()
+            trip.consumption, tmp_trip.delta_soc = tmp_trip.calculate_consumption()
             if soc >= -(trip.delta_soc + tmp_trip.delta_soc):
                 # next trip is possible: add trip, use info from original trip
                 trip_dict = vars(trip)

--- a/simba/optimization.py
+++ b/simba/optimization.py
@@ -345,7 +345,7 @@ def recombination(schedule, args, trips, depot_trips):
             # rotation.add_trip needs dict, but consumption calculation is better done on Trip obj:
             # create temporary depot trip object for consumption calculation
             tmp_trip = Trip(rotation, **depot_trip)
-            trip.consumption, tmp_trip.delta_soc = tmp_trip.calculate_consumption()
+            tmp_trip.consumption, tmp_trip.delta_soc = tmp_trip.calculate_consumption()
             if soc >= -(trip.delta_soc + tmp_trip.delta_soc):
                 # next trip is possible: add trip, use info from original trip
                 trip_dict = vars(trip)

--- a/simba/rotation.py
+++ b/simba/rotation.py
@@ -206,5 +206,6 @@ def get_idle_consumption(first_trip: Trip, second_trip: Trip, vehicle_info: dict
         return 0, 0
 
     break_duration = second_trip.departure_time - first_trip.arrival_time
+    assert break_duration > 0
     idle_consumption = break_duration.total_seconds() / 3600 * idle_cons_spec
     return idle_consumption, -idle_consumption / capacity

--- a/simba/rotation.py
+++ b/simba/rotation.py
@@ -110,6 +110,7 @@ class Rotation:
             trip = next_trip
 
         if next_trip:
+            # last trip of the rotation has no idle consumption
             next_trip.consumption, next_trip.delta_soc = next_trip.calculate_consumption()
             rotation_consumption += next_trip.consumption
 

--- a/simba/rotation.py
+++ b/simba/rotation.py
@@ -85,6 +85,10 @@ class Rotation:
         :return: Consumption of rotation [kWh]
         :rtype: float
         """
+        if len(self.trips) == 0:
+            self.consumption = 0
+            return self.consumption
+
         # get the specific idle consumption of this vehicle type in kWh/h
         v_info = self.schedule.vehicle_types[self.vehicle_type][self.charging_type]
 
@@ -94,7 +98,6 @@ class Rotation:
         self.trips = list(sorted(self.trips, key=lambda trip: trip.arrival_time))
 
         trip = self.trips[0]
-        next_trip = None
         for next_trip in self.trips[1:]:
             # get consumption due to driving
             driving_consumption, driving_delta_soc = trip.calculate_consumption()
@@ -109,10 +112,9 @@ class Rotation:
             rotation_consumption += driving_consumption + idle_consumption
             trip = next_trip
 
-        if next_trip:
-            # last trip of the rotation has no idle consumption
-            next_trip.consumption, next_trip.delta_soc = next_trip.calculate_consumption()
-            rotation_consumption += next_trip.consumption
+        # last trip of the rotation has no idle consumption
+        trip.consumption, trip.delta_soc = trip.calculate_consumption()
+        rotation_consumption += trip.consumption
 
         self.consumption = rotation_consumption
         return rotation_consumption

--- a/simba/rotation.py
+++ b/simba/rotation.py
@@ -206,6 +206,6 @@ def get_idle_consumption(first_trip: Trip, second_trip: Trip, vehicle_info: dict
         return 0, 0
 
     break_duration = second_trip.departure_time - first_trip.arrival_time
-    assert break_duration > 0
+    assert break_duration.total_seconds() >= 0
     idle_consumption = break_duration.total_seconds() / 3600 * idle_cons_spec
     return idle_consumption, -idle_consumption / capacity

--- a/simba/trip.py
+++ b/simba/trip.py
@@ -112,4 +112,4 @@ class Trip:
 
         break_duration = self.rotation.trips[idx + 1].departure_time - self.arrival_time
         idle_consumption = break_duration.total_seconds() / 3600 * idle_cons_spec
-        return idle_consumption, idle_consumption / capacity
+        return idle_consumption, -idle_consumption / capacity

--- a/simba/trip.py
+++ b/simba/trip.py
@@ -63,7 +63,7 @@ class Trip:
         """
 
         try:
-            self.consumption, self.delta_soc = Trip.consumption.calculate_consumption(
+            driving_consumption, driving_delta_soc = Trip.consumption.calculate_consumption(
                 self.arrival_time,
                 self.distance,
                 self.rotation.vehicle_type,
@@ -72,9 +72,44 @@ class Trip:
                 height_diff=self.height_diff,
                 level_of_loading=self.level_of_loading,
                 mean_speed=self.mean_speed)
+
+            # Add idle consumption of the next break time
+            idle_consumption, idle_delta_soc = self.get_idle_consumption()
+
+            self.consumption = idle_consumption + driving_consumption
+            self.delta_soc = driving_delta_soc + idle_delta_soc
+
         except AttributeError as e:
             raise Exception(
                 'To calculate consumption, a consumption object needs to be constructed'
                 ' and linked to Trip class.').with_traceback(e.__traceback__)
 
         return self.consumption
+
+    def get_idle_consumption(self):
+        """ Compute consumption while waiting for the next trip
+
+        Idle consumption is added during rotations and not in depots. Idle consumption is added
+        to the trip consumption which should be a good approximation in most cases. Might lead
+        to small overestimation of charge at an electrified stations.
+        :return: Consumption of trip [kWh], delta_soc [-]
+        :rtype: float, float
+        """
+        vt, ct = self.rotation.vehicle_type, self.rotation.charging_type
+        # get the specific idle consumption of this vehicle type in kWh/h
+        vehicle_type = self.rotation.schedule.vehicle_types[vt][ct]
+        capacity = vehicle_type["capacity"]
+        idle_cons_spec = vehicle_type.get("idle_consumption", 0)
+        if idle_cons_spec == 0:
+            return 0, 0
+
+        # Get next trip
+        self.rotation.trips = list(
+            sorted(self.rotation.trips, key=lambda trip: trip.departure_time))
+        idx = self.rotation.trips.index(self)
+        if idx >= len(self.rotation.trips) - 1:
+            return 0, 0
+
+        break_duration = self.rotation.trips[idx + 1].departure_time - self.arrival_time
+        idle_consumption = break_duration.total_seconds() / 3600 * idle_cons_spec
+        return idle_consumption, idle_consumption / capacity

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -25,5 +25,8 @@ def generate_basic_schedule():
         "cs_power_deps_depb": 50,
         "cs_power_deps_oppb": 150
     }
+    generated_schedule =\
+        schedule.Schedule.from_csv(schedule_path, vehicle_types, stations, **mandatory_args)
+    generated_schedule.calculate_consumption()
 
-    return schedule.Schedule.from_csv(schedule_path, vehicle_types, stations, **mandatory_args)
+    return generated_schedule

--- a/tests/test_consumption.py
+++ b/tests/test_consumption.py
@@ -19,7 +19,6 @@ class TestConsumption:
         rotation = schedule.rotations["1"]
         first_trip = rotation.trips[0]
         second_trip = rotation.trips[1]
-        last_trip = rotation.trips[-1]
 
         # shift all trips except the first
         for t in schedule.rotations["1"].trips[1:]:
@@ -45,10 +44,6 @@ class TestConsumption:
         assert idle_consumption == 0.5
 
         second_trip.departure_time = first_trip.arrival_time
-        idle_consumption, idle_delta_soc = get_idle_consumption(first_trip, second_trip, v_info)
-        assert idle_consumption == 0
-
-        # Last trip has no following trip, therefore no idle consumption
         idle_consumption, idle_delta_soc = get_idle_consumption(first_trip, second_trip, v_info)
         assert idle_consumption == 0
 

--- a/tests/test_consumption.py
+++ b/tests/test_consumption.py
@@ -1,13 +1,69 @@
 import pytest
 from tests.test_schedule import BasicSchedule
 from tests.conftest import example_root
-from datetime import datetime
+from datetime import datetime, timedelta
 import pandas as pd
 
 
 class TestConsumption:
     """Class to test Consumption functionality"""
     consumption_path = example_root / "energy_consumption_example.csv"
+
+    def test_calculate_idle_consumption(self, tmp_path):
+        """Various tests to trigger errors and check if behaviour is as expected
+
+        :param tmp_path: pytest fixture to create a temporary path
+        """
+        schedule, scenario, args = BasicSchedule().basic_run()
+        first_trip = schedule.rotations["1"].trips[0]
+        second_trip = schedule.rotations["1"].trips[1]
+        last_trip = schedule.rotations["1"].trips[-1]
+
+        # shift all trips except the first
+        for t in schedule.rotations["1"].trips[1:]:
+            t.arrival_time = t.arrival_time + timedelta(minutes=70)
+            t.departure_time = t.departure_time + timedelta(minutes=70)
+
+        vt, ct = schedule.rotations["1"].vehicle_type, schedule.rotations["1"].charging_type
+        vehicle_type = schedule.vehicle_types[vt][ct]
+        vehicle_type["idle_consumption"] = 0
+
+        # Make sure that there is a break duration.
+        # By shifing all trips earlier we made sure that this "second_trip" stays the second trip
+        second_trip.departure_time = first_trip.arrival_time + timedelta(minutes=60)
+        idle_consumption, idle_delta_soc = first_trip.get_idle_consumption()
+        assert idle_consumption == 0
+        vehicle_type["idle_consumption"] = 1
+        second_trip.departure_time = first_trip.arrival_time + timedelta(minutes=60)
+        idle_consumption, idle_delta_soc = first_trip.get_idle_consumption()
+        assert idle_consumption == 1
+
+        second_trip.departure_time = first_trip.arrival_time + timedelta(minutes=30)
+        idle_consumption, idle_delta_soc = first_trip.get_idle_consumption()
+        assert idle_consumption == 0.5
+
+        second_trip.departure_time = first_trip.arrival_time
+        idle_consumption, idle_delta_soc = first_trip.get_idle_consumption()
+        assert idle_consumption == 0
+
+        # Last trip has no following trip, therefore no idle consumption
+        idle_consumption, idle_delta_soc = last_trip.get_idle_consumption()
+        assert idle_consumption == 0
+
+        # Check that assignment of vehicles changes due to increased consumption. Only works
+        # with adaptive_soc assignment
+        for vt in schedule.vehicle_types.values():
+            for ct in vt:
+                vt[ct]["idle_consumption"] = 0
+        schedule.assign_vehicles_w_adaptive_soc(args)
+        no_idle_consumption = schedule.vehicle_type_counts.copy()
+
+        for vt in schedule.vehicle_types.values():
+            for ct in vt:
+                vt[ct]["idle_consumption"] = 9999
+        schedule.calculate_consumption()
+        schedule.assign_vehicles_w_adaptive_soc(args)
+        assert no_idle_consumption["AB_depb"] * 2 == schedule.vehicle_type_counts["AB_depb"]
 
     def test_calculate_consumption(self, tmp_path):
         """Various tests to trigger errors and check if behaviour is as expected

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -1,3 +1,4 @@
+from simba.rotation import Rotation
 from tests.helpers import generate_basic_schedule
 
 
@@ -27,3 +28,29 @@ def test_set_charging_type():
     # check that the consumption changed due to the change in charging type. The proper calculation
     # of consumption is tested in test_consumption
     assert rot.consumption != consumption_oppb
+
+
+def test_calculate_consumption():
+    s = generate_basic_schedule()
+    vt = next(iter(s.vehicle_types))
+
+    r = Rotation("my_rot", vt, s)
+    # consumption without trips
+    assert r.calculate_consumption() == 0
+
+    some_rot = next(iter(s.rotations.values()))
+    first_trip = some_rot.trips[0]
+    first_trip.charging_type = "depb"
+    del first_trip.rotation
+    r.add_trip(vars(first_trip))
+    r.trips[0].consumption = None
+    r.calculate_consumption()
+    assert r.trips[0].consumption is not None
+    second_trip = some_rot.trips[1]
+    del second_trip.rotation
+    r.add_trip(vars(second_trip))
+    for trip in r.trips:
+        trip.consumption = None
+    r.calculate_consumption()
+    for trip in r.trips:
+        assert trip.consumption is not None

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -112,6 +112,7 @@ class TestSchedule(BasicSchedule):
         path_to_trips = file_root / "trips_assign_vehicles_extended.csv"
         generated_schedule = schedule.Schedule.from_csv(
             path_to_trips, self.vehicle_types, self.electrified_stations, **mandatory_args)
+        generated_schedule.calculate_consumption()
         all_rotations = [r for r in generated_schedule.rotations]
         args = Namespace(**{})
         args.assign_strategy = "fixed_recharge"
@@ -342,6 +343,7 @@ class TestSchedule(BasicSchedule):
         generated_schedule = schedule.Schedule.from_csv(
             path_to_trips, self.vehicle_types, electrified_stations, **mandatory_args,
             station_data_path=path_to_all_station_data)
+        generated_schedule.calculate_consumption()
 
         set_options_from_config(args, verbose=False)
         args.ALLOW_NEGATIVE_SOC = True
@@ -364,6 +366,7 @@ class TestSchedule(BasicSchedule):
         generated_schedule = schedule.Schedule.from_csv(
             path_to_trips, self.vehicle_types, electrified_stations, **mandatory_args,
             station_data_path=path_to_all_station_data)
+        generated_schedule.calculate_consumption()
 
         set_options_from_config(args, verbose=False)
 
@@ -453,6 +456,7 @@ class TestSchedule(BasicSchedule):
         # generate events to lower GC max power during peak load windows
         # setup basic schedule (reuse during test)
         generated_schedule = generate_basic_schedule()
+
         sys.argv = ["foo", "--config", str(example_root / "simba.cfg")]
         args = util.get_args()
         for station in generated_schedule.stations.values():


### PR DESCRIPTION
Adds simplified feature of idle consumption.
Trip.consumption now also takes into account the next break duration and adds idle consumption.  vehicle_types now have the optional parameter "idle_consumption" in kWh/h = kW.
The consumption is not subtracted during the break but during the trip duration. This might lead to minor overestimation of charge at electrified stations but is much easier implemented than a simultaneous discharge while at a station (and possibly charging).

Vehicle assignment with adaptive_socs is correctly affected by this change. Optimization of rotations / Rotation splitting at the current stage does not take idle_consumption into account