### PR TITLE
new option create_trips_in_report

### DIFF
--- a/data/examples/simba.cfg
+++ b/data/examples/simba.cfg
@@ -43,7 +43,7 @@ mode = ["sim", "report"]
 ##### Flags #####
 ### Activate optional functions ###
 # Set flag for cost calculation: (default: false)
-cost_calculation = false
+cost_calculation = true
 # Check rotation assumptions when building schedule? (default: false)
 check_rotation_consistency = false
 # Remove rotations from schedule that violate assumptions?

--- a/data/examples/simba.cfg
+++ b/data/examples/simba.cfg
@@ -43,19 +43,21 @@ mode = ["sim", "report"]
 ##### Flags #####
 ### Activate optional functions ###
 # Set flag for cost calculation: (default: false)
-cost_calculation = true
+cost_calculation = false
 # Check rotation assumptions when building schedule? (default: false)
 check_rotation_consistency = false
 # Remove rotations from schedule that violate assumptions?
 # Needs check_rotation_consistency to have an effect (default: false)
 skip_inconsistent_rotations = false
 # Show plots for users to view, only used in mode report (default: false)
-show_plots = true
+show_plots = false
 # Rotation filter variable, options:
 # "include": include only the rotations from file 'rotation_filter'
 # "exclude": exclude the rotations from file 'rotation_filter' from the schedule
 # null: deactivate function
 rotation_filter_variable = null
+# Write a new trips.csv during report mode to output directory? (default: false)
+create_trips_in_report = false
 
 ##### Charging strategy #####
 # Preferred charging type. Options: depb, oppb (default: depb)

--- a/simba/report.py
+++ b/simba/report.py
@@ -2,6 +2,7 @@
 import csv
 import datetime
 import logging
+import re
 from typing import Iterable
 
 import matplotlib.pyplot as plt
@@ -130,12 +131,17 @@ def generate_trips_timeseries_data(schedule):
         # "distance", "temperature", "height_diff", "level_of_loading", "mean_speed",
     ]
     data = [header]
-    for rotation in schedule.rotations.values():
+    rotations = schedule.rotations.values()
+    # sort rotations naturally by ID
+    rotations = sorted(rotations, key=lambda r: [
+        # natural sort: split by numbers, then sort numbers by value and chars by lowercase
+        int(s) if s.isdigit() else s.lower() for s in re.split(r'(\d+)', r.id)])
+    for rotation in rotations:
         for trip in rotation.trips:
             # get trip info from trip or trip.rotation (same name in Trip/Rotation as in CSV)
             row = [vars(trip).get(k, vars(trip.rotation).get(k)) for k in header]
             # special case rotation_id
-            row[0] = trip.rotation.id
+            row[0] = rotation.id
             data.append(row)
     return data
 

--- a/simba/trip.py
+++ b/simba/trip.py
@@ -42,7 +42,7 @@ class Trip:
         mean_speed = kwargs.get("mean_speed", (self.distance / 1000) /
                                 max(1 / 60, ((self.arrival_time - self.departure_time) / timedelta(
                                     hours=1))))
-        self.mean_speed = mean_speed
+        self.mean_speed = float(mean_speed)
 
         # Attention: Circular reference!
         # While a rotation carries a references to this trip, this trip

--- a/simba/util.py
+++ b/simba/util.py
@@ -305,6 +305,8 @@ def get_args():
     parser.add_argument('--propagate-mode-errors', default=False,
                         help='Re-raise errors instead of continuing during simulation modes')
     parser.add_argument('--create-scenario-file', help='Write scenario.json to file')
+    parser.add_argument('--create-trips-in-report', action='store_true',
+                        help='Write a trips.csv during report mode')
     parser.add_argument('--rotation-filter-variable', default=None,
                         choices=[None, 'include', 'exclude'],
                         help='set mode for filtering schedule rotations')

--- a/tests/test_schedule.py
+++ b/tests/test_schedule.py
@@ -459,6 +459,7 @@ class TestSchedule(BasicSchedule):
 
         sys.argv = ["foo", "--config", str(example_root / "simba.cfg")]
         args = util.get_args()
+        args.cost_calculation = True  # needed for timeseries, but default is false
         for station in generated_schedule.stations.values():
             station["gc_power"] = 1000
             station.pop("peak_load_window_power", None)

--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -147,6 +147,27 @@ class TestSimulate:
             warnings.simplefilter("ignore")
             simulate(Namespace(**values))
 
+    def test_create_trips_in_report(self, tmp_path):
+        # create_trips_in_report option: must generate valid input trips.csv
+        values = self.DEFAULT_VALUES.copy()
+        values.update({
+            "mode": ["report"],
+            "desired_soc_deps": 0,
+            "ALLOW_NEGATIVE_SOC": True,
+            "cost_calculation": False,
+            "output_directory": tmp_path,
+            "show_plots": False,
+            "create_trips_in_report": True,
+        })
+        # simulate base scenario, report generates new trips.csv in (tmp) output
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            simulate(Namespace(**values))
+        # new simulation with generated trips.csv
+        values = self.DEFAULT_VALUES.copy()
+        values["input_schedule"] = tmp_path / "report_1/trips.csv"
+        simulate(Namespace(**(values)))
+
     def test_mode_recombination(self):
         values = self.DEFAULT_VALUES.copy()
         values["mode"] = "recombination"


### PR DESCRIPTION
If new option is set, a file named trips.csv will be created in the output folder during each report mode, containing the current state of trips. This file can be used as a new input file for later simulations.
Resolves #198 