### PR TITLE
Compatibility patch for SpiceEV PR #217

### DIFF
--- a/data/examples/simba.cfg
+++ b/data/examples/simba.cfg
@@ -76,9 +76,9 @@ strategy_opps = greedy
 strategy_options_deps = {"CONCURRENCY": 1}
 strategy_options_opps = {}
 
-# Cost calculation strategy
-cost_calculation_strategy_deps = balanced
-cost_calculation_strategy_opps = greedy
+# Cost calculation to use. Remove to use default for strategy.
+cost_calculation_method_deps = fixed_wo_plw
+cost_calculation_method_opps = fixed_wo_plw
 
 ##### Physical setup of environment #####
 ### Parametrization of the physical setup ###

--- a/data/examples/simba.cfg
+++ b/data/examples/simba.cfg
@@ -77,6 +77,7 @@ strategy_options_deps = {"CONCURRENCY": 1}
 strategy_options_opps = {}
 
 # Cost calculation to use. Remove to use default for strategy.
+# Options: fixed_wo_plw, fixed_w_plw, variable_wo_plw, variable_w_plw, balanced_market, flex_window
 cost_calculation_method_deps = fixed_wo_plw
 cost_calculation_method_opps = fixed_wo_plw
 

--- a/docs/source/simulation_parameters.rst
+++ b/docs/source/simulation_parameters.rst
@@ -106,11 +106,11 @@ The example (data/simba.cfg) contains parameter descriptions which are explained
      - Charging strategy used in opportunity stations.
    * - cost_calculation_method_deps
      - fixed_wo_plw
-     - SpiceEV cost calculation type
+     - SpiceEV cost calculation type (fixed_wo_plw, fixed_w_plw, variable_wo_plw, variable_w_plw, balanced_market, flex_window)
      - Method for cost calculation at depots.
    * - cost_calculation_method_opps
      - fixed_wo_plw
-     - SpiceEV cost calculation type (fixed_wo_plw, fixed_w_plw, balanced_market, flex_window)
+     - SpiceEV cost calculation type, same choices as in depot
      - Method for cost calculation at opportunity stations.
    * - preferred_charging_type
      - depb

--- a/docs/source/simulation_parameters.rst
+++ b/docs/source/simulation_parameters.rst
@@ -104,14 +104,14 @@ The example (data/simba.cfg) contains parameter descriptions which are explained
      - greedy
      - SpiceEV Strategies (greedy, balanced, peak_shaving, peak_load_windows, balanced_market)
      - Charging strategy used in opportunity stations.
-   * - cost_calculation_strategy_deps
-     - strategy_deps value
-     - SpiceEV Strategies (greedy, balanced, peak_shaving, peak_load_windows, balanced_market)
-     - Strategy for cost calculation at depots.
-   * - cost_calculation_strategy_opps
-     - strategy_opps value
-     - SpiceEV Strategies (greedy, balanced, peak_shaving, peak_load_windows, balanced_market)
-     - Strategy for cost calculation at opportunity stations.
+   * - cost_calculation_method_deps
+     - fixed_wo_plw
+     - SpiceEV cost calculation type
+     - Method for cost calculation at depots.
+   * - cost_calculation_method_opps
+     - fixed_wo_plw
+     - SpiceEV cost calculation type (fixed_wo_plw, fixed_w_plw, balanced_market, flex_window)
+     - Method for cost calculation at opportunity stations.
    * - preferred_charging_type
      - depb
      - depb, oppb

--- a/simba/util.py
+++ b/simba/util.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 from datetime import datetime, timedelta
 
+from spice_ev.costs import COST_CALCULATION
 from spice_ev.strategy import STRATEGIES
 from spice_ev.util import set_options_from_config
 
@@ -531,11 +532,11 @@ def get_parser():
     parser.add_argument('--strategy-opps', default='greedy', choices=STRATEGIES,
                         help='strategy to use at station')
 
-    # #### Cost calculation strategy #####
-    parser.add_argument('--cost-calculation-strategy-deps', choices=STRATEGIES,
-                        help='Strategy for cost calculation to use in depot')
-    parser.add_argument('--cost-calculation-strategy-opps', choices=STRATEGIES,
-                        help='Strategy for cost calculation to use at station')
+    # #### Cost calculation method #####
+    parser.add_argument('--cost-calculation-method-deps', choices=COST_CALCULATION,
+                        help='Cost calculation to use in depot')
+    parser.add_argument('--cost-calculation-method-opps', choices=COST_CALCULATION,
+                        help='Cost calculation to use at station')
 
     parser.add_argument('--strategy-options-deps', default={},
                         type=lambda s: s if type(s) is dict else json.loads(s),

--- a/tests/test_cost_calculation.py
+++ b/tests/test_cost_calculation.py
@@ -13,16 +13,16 @@ class TestCostCalculation:
         assert args.strategy_deps == "balanced"
         assert args.strategy_opps == "greedy"
 
-        args.cost_calculation_strategy_deps = None
-        args.cost_calculation_strategy_opps = None
+        args.cost_calculation_method_deps = None
+        args.cost_calculation_method_opps = None
 
         costs_vanilla = calculate_costs(cost_params, scenario, schedule, args)
 
         assert args.strategy_deps == "balanced"
         assert args.strategy_opps == "greedy"
 
-        args.cost_calculation_strategy_deps = "balanced"
-        args.cost_calculation_strategy_opps = "greedy"
+        args.cost_calculation_method_deps = "fixed_wo_plw"
+        args.cost_calculation_method_opps = "fixed_wo_plw"
         costs_with_same_strat = calculate_costs(cost_params, scenario, schedule, args)
 
         # assert all costs are the same
@@ -31,8 +31,9 @@ class TestCostCalculation:
                 assert (costs_vanilla.costs_per_gc[station][key] ==
                         costs_with_same_strat.costs_per_gc[station][key]), station
 
-        args.cost_calculation_strategy_opps = "balanced_market"
-        args.cost_calculation_strategy_deps = "balanced_market"
+        # test with different method (balanced_market costs for balanced strategy)
+        args.cost_calculation_method_deps = "balanced_market"
+        args.cost_calculation_method_opps = "balanced_market"
         costs_with_other_strat = calculate_costs(cost_params, scenario, schedule, args)
         print(costs_vanilla.costs_per_gc["cumulated"]["c_total_annual"])
         print(costs_with_other_strat.costs_per_gc["cumulated"]["c_total_annual"])
@@ -43,21 +44,15 @@ class TestCostCalculation:
             assert (costs_vanilla.costs_per_gc[station][key] !=
                     costs_with_other_strat.costs_per_gc[station][key]), key
 
-        args.cost_calculation_strategy_opps = "peak_load_window"
-        args.cost_calculation_strategy_deps = "peak_load_window"
+        # PLW: will create window time series before cost calculation
+        args.cost_calculation_method_deps = "fixed_w_plw"
+        args.cost_calculation_method_opps = "fixed_w_plw"
         costs_with_other_strat = calculate_costs(cost_params, scenario, schedule, args)
+        """
         station = "cumulated"
         for key in costs_vanilla.costs_per_gc[station]:
             if "el_energy" not in key:
                 continue
             assert (costs_vanilla.costs_per_gc[station][key] !=
-                    costs_with_other_strat.costs_per_gc[station][key]), key
-
-        args.cost_calculation_strategy_opps = "peak_shaving"
-        args.cost_calculation_strategy_deps = "peak_shaving"
-        costs_with_other_strat = calculate_costs(cost_params, scenario, schedule, args)
-        # assert all costs are the same
-        for station in costs_vanilla.costs_per_gc:
-            for key in costs_vanilla.costs_per_gc[station]:
-                assert (costs_vanilla.costs_per_gc[station][key] ==
-                        costs_with_other_strat.costs_per_gc[station][key]), station
+                costs_with_other_strat.costs_per_gc[station][key]), key
+        """


### PR DESCRIPTION
refactor costs PR: https://github.com/rl-institut/spice_ev/pull/217

- rename cost_calculation_strategy_X to cost_calculation_method_X
- use cost calc types instead of strategy names
- create window timeseries for PLW costs
- test: remove peak_shaving cost calc test (also fixed_wo_plw, so no different to greedy/balanced), fixed_w_plw generates same el. costs